### PR TITLE
fixed kernel.json to new name, alt. way install kernelspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A simple kernel that adds the  [Dart programming language](https://Dart.org) int
 3. Download the kernel and save it somewhere memorable.
 4. Open shell in project folder
 5. `pip install -e ./`
-6. `jupyter kernelspec install --user jupyterdartkernel`
+6. `jupyterdartkernel` or `jupyter kernelspec install --user jupyterdartkernel`
   - To use the kernel in the Jupyter console: `jupyter console --kernel jupyterdartkernel`
   - to use the kernel in a notebook: `jupyter notebook` and create a new notebook through the browser
   

--- a/jupyterdartkernel/kernel.json
+++ b/jupyterdartkernel/kernel.json
@@ -1,3 +1,3 @@
-{"argv":["python","-m","jupyter-dart-kernel", "-f", "{connection_file}"],
+{"argv":["python","-m","jupyterdartkernel", "-f", "{connection_file}"],
 	"display_name":"Dart"
 }


### PR DESCRIPTION
This should fix the installation via jupyter kernelspec.
Also added alternative installscript to the pyproject.toml.
You can just run `jupyterdartkernel` after the pip install to install the kernelspec.
That's why i got rid of the hyphens in the first place :-)
