### PR TITLE
Feature: Resolve Dependencies Through Jupyter Notebook Cell 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ A simple kernel that adds the  [Dart programming language](https://Dart.org) int
 6. `jupyterdartkernel` or `jupyter kernelspec install --user jupyterdartkernel`
   - To use the kernel in the Jupyter console: `jupyter console --kernel jupyterdartkernel`
   - to use the kernel in a notebook: `jupyter notebook` and create a new notebook through the browser
-  
+  - to add a package use a comment with package name and version in `dart pub add` format in the end of the line  
+  ```dart
+  import 'package:xml/xml.dart';           //xml: ^6.3.0
+  import 'package:sprintf/sprintf.dart';   //sprintf: "^7.0.0"
+  import 'package:intl/intl.dart';         //intl: "^0.18.1"
+  import 'package:xml2json/xml2json.dart'; //xml2json: ^6.2.1
+  import 'package:http/http.dart' as http; //http: ^1.1.0
+  ```
+
 ## Uninstall
 
 - `jupyter kernelspec uninstall jupyterdartkernel`

--- a/src/jupyterdartkernel/kernel.py
+++ b/src/jupyterdartkernel/kernel.py
@@ -10,7 +10,23 @@ class dartkernel(Kernel):
     language_version = '2.18.5'
     language_info = {'mimetype': 'application/dart', 'file_extension': 'dart', 'name': 'dart'}
     banner = "Dart kernel"
-    
+
+    # pubspec.yaml template
+    pubspec = ("name: dart_kernel_app\n"
+               "description: A dart kernel depenency controller.\n"
+               "publish_to: 'none'\n"
+               "\n"
+               "version: 1.0.0+1\n"
+               "\n"
+               "environment:\n"
+               "  sdk: '>=3.1.5 <4.0.0'\n"
+               ""
+               "dependencies:\n"
+               "  flutter:\n"
+               "    sdk: flutter\n"
+               "\n"
+               "%s")
+
     output = ""
     dartDirectory = tempfile.mkdtemp()
     
@@ -56,7 +72,8 @@ class dartkernel(Kernel):
         dartFileLocation = os.path.join(self.dartDirectory, 'scratch.dart')
         canonicalFile = os.path.join(self.dartDirectory, 'canonical.dart')
         runFile = os.path.join(self.dartDirectory, 'main.dart')
-        
+        specFile = os.path.join(self.dartDirectory, 'pubspec.yaml')
+    
         if os.path.isfile(canonicalFile):
             shutil.copyfile(canonicalFile, dartFileLocation)
         
@@ -96,10 +113,23 @@ class dartkernel(Kernel):
         wf.write("\n")
         wf.writelines(code_lines)
         wf.close()
-
-        error_output = []
         
-        cmd = 'dart {0}'.format(runFile)
+        if import_lines:
+            # write the pubspec.yaml file to the template direcotory
+            with open(specFile, "w") as f:
+                # extract package name and version from comment in the end of the import line
+                # example of the comment:
+                # `xml: ^6.3.0`
+                # `intl: "^0.18.1"`
+                imp = re.findall("^\s*import[^;]+;\s*\/\/\s*(\w+):(.*)", "\n".join(import_lines), re.MULTILINE)
+                spec = "\n".join( "  %s: %s" % (x[0].strip(), x[1].strip()) for x in imp )
+                f.write(self.pubspec % spec)
+        
+        error_output = []
+        os.chdir(self.dartDirectory)
+
+        # run resolve dependencies before run 
+        cmd = 'dart pub get; dart {0}'.format(runFile)
         dart = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         new_output = dart.stdout.read()
 


### PR DESCRIPTION
## Description 
What does this pull request do? 
This feature introduces the ability to import dependencies seamlessly without requiring additional actions. The goal is to streamline the process of using Dart with the Jupyter Notebook kernel, especially for users less familiar with the Dart language, ultimately saving time for all users. 
 
## Why is this pull request needed? 
Currently, users face challenges when handling dependencies in Dart Jupyter notebooks. This feature aims to simplify the experience, making it more accessible for users unfamiliar with Dart and enhancing efficiency for everyone else. 
 
## How did you implement the solution? 
The implementation involves writing a `pubspec.yaml` file to a temporary directory adjacent to the main Dart program. Subsequently, the Dart standard dependency resolver is invoked to resolve and import the necessary dependencies. 
 
## Additional context 
This enhancement not only makes the dependency resolution process more user-friendly but also ensures a smoother experience for those working with Dart in Jupyter notebooks. 
 
## Checklist 
 - [x] I have thoroughly tested my changes. 
 - [x] My code adheres to the project's coding standards. 
 - [x] The documentation has been updated to reflect the changes. 
 - [x] Any conflicts with the latest code have been checked and resolved. 

## Related Issues 
Reference any related issues or pull requests that are addressed or resolved by this pull request.